### PR TITLE
Added support for 2020.11.4s + standardized scripts a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,5 @@ tmp
 /.idea/
 
 Il2CppInspector*
+
+gamepath.bat

--- a/.gitignore
+++ b/.gitignore
@@ -365,3 +365,5 @@ tmp
 /cmake-build-release/
 /cmake-build-debug/
 /.idea/
+
+Il2CppInspector*

--- a/AUMInjector/user/main.cpp
+++ b/AUMInjector/user/main.cpp
@@ -12,8 +12,9 @@
 
 #define GAME_VERSION_2020_9_22s 2020922
 #define GAME_VERSION_2020_10_22s 20201022
+#define GAME_VERSION_2020_11_4s 20201104
 #ifndef GAME_VERSION
-    #define GAME_VERSION GAME_VERSION_2020_10_22s
+    #define GAME_VERSION GAME_VERSION_2020_11_4s
 #endif
 
 using namespace app;
@@ -46,6 +47,22 @@ using namespace app;
     #define MeetingHud_Close_Trampoline GPOHFPAIEMA_Close
     #define MeetingHud_Start_Trampoline GPOHFPAIEMA_Start
     #define InnerNetClient_FixedUpdate_Trampoline DNAFMCDBMCI_FixedUpdate
+
+#elif GAME_VERSION == GAME_VERSION_2020_11_4s
+    #define version_text "2020.11.4s"
+    using InnerNetClient_GameState__Enum = DBDDAJAICFN_DKEKFCCGGEO__Enum;
+    using PlayerControl = APNNOJFGDGP;
+    using Player_Die_Reason__Enum = LKBAAGPFMCB__Enum;
+    using MeetingHud = LFBAPIAFCFM;
+    using InnerNetClient = DBDDAJAICFN;
+    InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Joined = DBDDAJAICFN_DKEKFCCGGEO__Enum_Joined;
+    InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended = DBDDAJAICFN_DKEKFCCGGEO__Enum_Ended;
+    #define PlayerControl_FixedUpdate_Trampoline APNNOJFGDGP_FixedUpdate
+    #define PlayerControl_GetTruePosition_Trampoline APNNOJFGDGP_GetTruePosition
+    #define PlayerControl_Die_Trampoline APNNOJFGDGP_Die
+    #define MeetingHud_Close_Trampoline LFBAPIAFCFM_Close
+    #define MeetingHud_Start_Trampoline LFBAPIAFCFM_Start
+    #define InnerNetClient_FixedUpdate_Trampoline DBDDAJAICFN_FixedUpdate
 #else
     #error Unknown game version!
 #endif

--- a/decompile.bat
+++ b/decompile.bat
@@ -1,11 +1,11 @@
 @echo off
 
-set "AMONGUS=D:\Steam\steamapps\common\Among Us"
+gamepath.bat
 
 mkdir tmp
 cd tmp
 
-Il2CppInspector-cli.exe -i "%AMONGUS%\GameAssembly.dll" -m "%AMONGUS%\Among Us_Data\il2cpp_data\Metadata\global-metadata.dat" -h "cpp" --cpp-compiler MSVC
+..\Il2CppInspector-cli.exe -i "%AMONGUS%\GameAssembly.dll" -m "%AMONGUS%\Among Us_Data\il2cpp_data\Metadata\global-metadata.dat" -h "cpp" --cpp-compiler MSVC
 xcopy "cpp\appdata\*.*" "..\AUMInjector\appdata\" /K /D /H /Y
 
 cd ..

--- a/gamepath.bat
+++ b/gamepath.bat
@@ -1,0 +1,3 @@
+@echo off
+Rem set here the path to your game folder
+set "AMONGUS=C:\Steam\steamapps\common\Among Us"

--- a/vmupload.bat
+++ b/vmupload.bat
@@ -1,2 +1,3 @@
-copy /b /v /y "..\Release\winhttp.dll" "D:\Steam\steamapps\common\Among Us\winhttp.dll"
-for %%x in (A B C) do copy /b /v /y "..\Release\winhttp.dll" "\\GAMECLIENT%%x\Users\Christoph\Desktop\Among Us\winhttp.dll"
+@echo off
+gamepath.bat
+copy /b /v /y ".\Release\winhttp.dll" "%AMONGUS%\winhttp.dll"


### PR DESCRIPTION
I added the obfuscated names for 2020.11.4s and I also edited decompile.bat and vmupload.bat to use a new gamepath.bat file and also edited the scripts a bit to make compilation easier for new contributors.

The wiki page will also need to be edited