### PR TITLE
Imposter radio

### DIFF
--- a/AUMDeobfuscator/MatcherDefinitions.cs
+++ b/AUMDeobfuscator/MatcherDefinitions.cs
@@ -35,7 +35,8 @@ namespace AUMDeobfuscator
                     .WithTag("FixedUpdate")
                     .OfName("FixedUpdate")
                     .WithNamedReturnType("void");
-            
+
+
             public static readonly ClassMatch ClassPlayerControl =
                 new ClassMatch()
                     .WithTag("PlayerControl")
@@ -51,9 +52,6 @@ namespace AUMDeobfuscator
                     .And()
                     .WithMethod(Die)
                     .And();
-
-
-            
 
 
         }
@@ -75,8 +73,6 @@ namespace AUMDeobfuscator
                 new EnumValueMatch(null!)
                     .OfName("Ended")
                     .OfValue("3");
-
-            
 
             public static readonly MethodMatch FixedUpdate =
                 new MethodMatch(null!)

--- a/AUMInjector/AUMInjector.vcxproj
+++ b/AUMInjector/AUMInjector.vcxproj
@@ -174,7 +174,7 @@
       <PreprocessToFile>false</PreprocessToFile>
       <DisableSpecificWarnings>4359</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/AUMInjector/AUMInjector.vcxproj
+++ b/AUMInjector/AUMInjector.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClCompile Include="framework\helpers.cpp" />
     <ClCompile Include="framework\il2cpp-init.cpp" />
+    <ClCompile Include="framework\Input.cpp" />
     <ClCompile Include="gui\Blocks\AboutBlock.cpp" />
     <ClCompile Include="gui\Blocks\OverlayBlock.cpp" />
     <ClCompile Include="gui\Blocks\PlayerInfoBlock.cpp" />
@@ -56,6 +57,7 @@
     <ClInclude Include="framework\helpers.h" />
     <ClInclude Include="framework\il2cpp-appdata.h" />
     <ClInclude Include="framework\il2cpp-init.h" />
+    <ClInclude Include="framework\Input.h" />
     <ClInclude Include="gui\Blocks\AboutBlock.h" />
     <ClInclude Include="gui\Blocks\OverlayBlock.h" />
     <ClInclude Include="gui\Blocks\PlayerInfoBlock.h" />
@@ -172,6 +174,7 @@
       <PreprocessToFile>false</PreprocessToFile>
       <DisableSpecificWarnings>4359</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/AUMInjector/AUMInjector.vcxproj.filters
+++ b/AUMInjector/AUMInjector.vcxproj.filters
@@ -102,6 +102,9 @@
     <ClCompile Include="gui\Blocks\AboutBlock.cpp">
       <Filter>GUI\Blocks</Filter>
     </ClCompile>
+    <ClCompile Include="framework\Input.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -232,6 +235,9 @@
     </ClInclude>
     <ClInclude Include="deobfuscate\2020_12_9s.h">
       <Filter>Deobfuscate</Filter>
+    </ClInclude>
+    <ClInclude Include="framework\Input.h">
+      <Filter>Include</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/AUMInjector/deobfuscate/2020_12_9s.h
+++ b/AUMInjector/deobfuscate/2020_12_9s.h
@@ -31,3 +31,5 @@ InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended = KHNHJFFECB
 #define PlayerControl_RPC_SetInfected FFGALNAPKCD_RpcSetInfected
 #define PlayerControl_RemoveInfected FFGALNAPKCD_RemoveInfected
 #define PlayerControl_GetData FFGALNAPKCD_get_Data
+#define PlayerControl_TypeInfo FFGALNAPKCD__TypeInfo
+#define IsImposter DAPKNDBLKIA

--- a/AUMInjector/deobfuscate/2020_12_9s.h
+++ b/AUMInjector/deobfuscate/2020_12_9s.h
@@ -8,6 +8,7 @@ using HqHudOverrideTask = NIAFLKKACLE;
 using HudOverrideTask = LFOILEODBMA;
 using ChatController = GEHKHGLKFHE;
 using AmongUsClient = FMLLKEACGIO;
+using PlayerData = EGLJNOMOGNP_DCJMABDDJCF;
 InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Joined = KHNHJFFECBP_KGEKNMMAKKN__Enum_Joined;
 InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Started = KHNHJFFECBP_KGEKNMMAKKN__Enum_Started;
 InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended = KHNHJFFECBP_KGEKNMMAKKN__Enum_Ended;
@@ -27,3 +28,6 @@ InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended = KHNHJFFECB
 #define ChatController_AddChat_Trampoline GEHKHGLKFHE_AddChat
 #define MessageWriter_Write_Byte_Trampoline MessageWriter_Write_1
 #define AmongUsClient_OnPlayerJoined_Trampoline FMLLKEACGIO_BIEPKGFMACN
+#define PlayerControl_RPC_SetInfected FFGALNAPKCD_RpcSetInfected
+#define PlayerControl_RemoveInfected FFGALNAPKCD_RemoveInfected
+#define PlayerControl_GetData FFGALNAPKCD_get_Data

--- a/AUMInjector/framework/Input.cpp
+++ b/AUMInjector/framework/Input.cpp
@@ -1,0 +1,14 @@
+#include "Input.h"
+Input inputSingleton;
+
+// Expects input of 'A' to 'Z'
+void Input::SetKey(char key, bool value)
+{
+	keyboardKeys[key - 'A'] = value;
+}
+
+// Expects input of 'A' to 'Z'
+bool Input::GetKey(char key)
+{
+	return keyboardKeys[key - 'A'];
+}

--- a/AUMInjector/framework/Input.h
+++ b/AUMInjector/framework/Input.h
@@ -1,0 +1,14 @@
+// For now this is a thin wrapper around the keyboard keys 'A' to 'Z'
+// Note that keys have to be capitalized
+class Input
+{
+public:
+	void SetKey(char key, bool value);
+	bool GetKey(char key);
+
+private:
+	bool keyboardKeys['Z' - 'A'] = { 0 };
+};
+
+// One instance of this class exists in the program
+extern Input inputSingleton;

--- a/AUMInjector/gui/Blocks/PlayerInfoBlock.cpp
+++ b/AUMInjector/gui/Blocks/PlayerInfoBlock.cpp
@@ -1,6 +1,7 @@
 #include "PlayerInfoBlock.h"
 #include "imgui.h"
 #include "MumblePlayer.h"
+#include "LoggingSystem.h"
 
 PlayerInfoBlock::PlayerInfoBlock() {}
 
@@ -12,4 +13,5 @@ void PlayerInfoBlock::Update()
 	ImGui::Text("Player is a ghost: %s", mumblePlayer.IsGhost() ? "True" : "False");
 	ImGui::Text("Player is in a meeting: %s", mumblePlayer.IsInMeeting() ? "True" : "False");
 	ImGui::Text("Communications is sabotaged: %s", mumblePlayer.IsSabotaged() ? "True" : "False");
+	ImGui::Text("Player is an imposter: %s", mumblePlayer.IsImposter() ? "True" : "False");
 }

--- a/AUMInjector/gui/Blocks/SettingsBlock.cpp
+++ b/AUMInjector/gui/Blocks/SettingsBlock.cpp
@@ -9,6 +9,7 @@
 const char* booleanOptions[] = { "False", "True" };
 const char* voiceText[] = { "Purgatory", "Spectate", "Haunt" };
 const char* verbosityText[] = { "Error", "Warning", "Info", "Message", "Debug" };
+const char keyboardKeys[] = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' };
 
 
 SettingsBlock::SettingsBlock() { }
@@ -147,6 +148,28 @@ void SettingsBlock::Update()
         ImGui::TreePop();
     }
     BoolComboHelper(appSettings.disableOverlay, "overlay");
+
+    // Change hotkey for radio
+    if (ImGui::TreeNode("Imposter Radio Hotkey"))
+    {
+        ImGui::Text("Set the hotkey for the imposter-radio");
+        ImGui::TreePop();
+    }
+    // Radio combo
+    if (ImGui::BeginCombo("##combo", &appSettings.radioKey)) // The second parameter is the label previewed before opening the combo.
+    {
+        for (int n = 0; n < sizeof(keyboardKeys); n++)
+        {
+            bool isSelected = (appSettings.radioKey == keyboardKeys[n]); // You can store your selection however you want, outside or inside your objects
+            // Create local string for imgui string to print.
+            char localKey[] = { keyboardKeys[n], 0 };
+            if (ImGui::Selectable(localKey, isSelected))
+                appSettings.radioKey = keyboardKeys[n];
+                if (isSelected)
+                    ImGui::SetItemDefaultFocus();   // You may set the initial focus when opening the combo (scrolling + for keyboard navigation support)
+        }
+        ImGui::EndCombo();
+    }
 
     // Log File
     if (ImGui::TreeNode("Logfile path:"))

--- a/AUMInjector/gui/GUI.cpp
+++ b/AUMInjector/gui/GUI.cpp
@@ -39,6 +39,7 @@
 #include "Blocks/SettingsBlock.h"
 #include "Blocks/OverlayBlock.h"
 #include "Blocks/AboutBlock.h"
+#include "Input.h"
 
 IDXGISwapChain* SwapChain;
 ID3D11Device* Device;
@@ -68,6 +69,16 @@ LRESULT CALLBACK WndProcHook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     ImGui::GetIO().MousePos.y = (float)mPos.y;
 
     if (uMsg == WM_KEYUP && wParam == VK_DELETE) guiShowMenu = !guiShowMenu;
+
+    // Set the alphabet when it comes in.
+    if (uMsg == WM_KEYUP && wParam >= 'A' && wParam <= 'Z')
+    {
+        inputSingleton.SetKey(wParam, false);
+    }
+    else if (uMsg == WM_KEYDOWN && wParam >= 'A' && wParam <= 'Z')
+    {
+        inputSingleton.SetKey(wParam, true);
+    }
 
     ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam);
     if (io.WantCaptureMouse && 

--- a/AUMInjector/user/MumblePlayer.cpp
+++ b/AUMInjector/user/MumblePlayer.cpp
@@ -132,6 +132,31 @@ int MumblePlayer::GetNetID() { return netID; }
 // Sets the player's net ID
 void MumblePlayer::SetNetID(int id) { netID = id; }
 
+void MumblePlayer::SetImposter(bool imposter)
+{
+    this->isImposter = imposter;
+}
+
+void MumblePlayer::ClearImposter()
+{
+    this->isImposter = false;
+}
+
+bool MumblePlayer::IsImposter() const
+{
+    return this->isImposter;
+}
+
+bool MumblePlayer::IsUsingRadio() const
+{
+    return this->isUsingRadio;
+}
+
+void MumblePlayer::SetUsingRadio(bool usingRadio)
+{
+    this->isUsingRadio = usingRadio;
+}
+
 // In mumble (0.0f, 0.0f) lets users hear each other better
 void MumblePlayer::SetFullVolume()
 {
@@ -159,6 +184,10 @@ void MumblePlayer::SetPos(int i, float pos)
         default:
             posCache[i] = pos;
         }
+    } 
+    if (this->isUsingRadio) // If you're using radio, go away. (If people think meeting radio is a bug, we'll change it)
+    {
+        posCache[i] = radioOffset;
     }
 }
 

--- a/AUMInjector/user/MumblePlayer.h
+++ b/AUMInjector/user/MumblePlayer.h
@@ -75,6 +75,21 @@ public:
 	// Sets the player's net ID
 	void SetNetID(int id);
 
+	// Sets whether player is imposter
+	void SetImposter(bool imposter);
+	
+	// Clears player from being imposter
+	void ClearImposter();
+
+	// Returns if player is imposter
+	bool IsImposter() const;
+
+	// Returns if player is using radio
+	bool IsUsingRadio() const;
+
+	// Sets if the player is using radio
+	void SetUsingRadio(bool usingRadio);
+
 private:
 	// --- Ghost State --- 
 	// Is the player currently a ghost
@@ -115,6 +130,13 @@ private:
 	int netID = 0;
 
 	bool isHost = false;
+
+	// Imposter flag
+	bool isImposter = false;
+	// Using Radio flag
+	bool isUsingRadio = false;
+	// When you're using radio, teleport here
+	const float radioOffset = 19999.0f;
 
 	// Reads private information to display it to the user
 	friend class PlayerInfoBlock;

--- a/AUMInjector/user/main.cpp
+++ b/AUMInjector/user/main.cpp
@@ -64,6 +64,28 @@ void PlayerControl_FixedUpdate_Hook(PlayerControl* __this, MethodInfo* method)
         // Cache network ID
         mumblePlayer.SetNetID(__this->fields._.NetId);
     }
+
+    // Grab the local player off of Among Us Static variable in Player Control
+    PlayerControl* localPlayerControl = FFGALNAPKCD__TypeInfo->static_fields->LocalPlayer;
+    if (localPlayerControl == __this)
+    {
+        // From Player Control, get the Player Data
+        PlayerData* Data = PlayerControl_GetData(localPlayerControl, nullptr);
+        // And now we can get if we are imposter.
+        bool isImposter = Data->fields.DAPKNDBLKIA;
+        mumblePlayer.SetImposter(isImposter);
+        
+        // Set if player is using radio
+        mumblePlayer.SetUsingRadio(inputSingleton.GetKey(appSettings.radioKey));
+
+        // Check if player is imposter and using radio
+        if (mumblePlayer.IsImposter() && mumblePlayer.IsUsingRadio())
+        {
+            logger.Log(LOG_CODE::MSG, "Imposter Radio");
+            // Location is moved to internal value in update player next loop.
+        }
+    }
+
 }
 
 // Gets called when a player dies
@@ -158,28 +180,6 @@ void InnerNetClient_FixedUpdate_Hook(InnerNetClient* __this, MethodInfo* method)
         }
     }
     lastGameState = __this->fields.GameState;
-
-    // Grab the local player off of Among Us Static variable in Player Control
-    PlayerControl* localPlayerControl = FFGALNAPKCD__TypeInfo->static_fields->LocalPlayer;
-    if (localPlayerControl) 
-    {
-        // From Player Control, get the Player Data
-        PlayerData* Data = PlayerControl_GetData(localPlayerControl, nullptr);
-        // And now we can get if we are imposter.
-        bool isImposter = Data->fields.DAPKNDBLKIA;
-        mumblePlayer.SetImposter(isImposter);
-    }
-    // Set if player is using radio
-    mumblePlayer.SetUsingRadio(inputSingleton.GetKey(appSettings.radioKey));
-
-    // Check if player is imposter and using radio
-    if (mumblePlayer.IsImposter() && mumblePlayer.IsUsingRadio())
-    {
-        logger.Log(LOG_CODE::MSG, "Imposter Radio");
-        // Move his location to DEFINED
-        mumblePlayer.SetPosX(100);
-        mumblePlayer.SetPosY(100);
-    }
 
     if (mumbleLink.linkedMem != nullptr)
     {

--- a/AUMInjector/user/main.cpp
+++ b/AUMInjector/user/main.cpp
@@ -66,13 +66,13 @@ void PlayerControl_FixedUpdate_Hook(PlayerControl* __this, MethodInfo* method)
     }
 
     // Grab the local player off of Among Us Static variable in Player Control
-    PlayerControl* localPlayerControl = FFGALNAPKCD__TypeInfo->static_fields->LocalPlayer;
+    PlayerControl* localPlayerControl = PlayerControl_TypeInfo ->static_fields->LocalPlayer;
     if (localPlayerControl == __this)
     {
         // From Player Control, get the Player Data
         PlayerData* Data = PlayerControl_GetData(localPlayerControl, nullptr);
         // And now we can get if we are imposter.
-        bool isImposter = Data->fields.DAPKNDBLKIA;
+        bool isImposter = Data->fields.IsImposter;
         mumblePlayer.SetImposter(isImposter);
         
         // Set if player is using radio
@@ -405,4 +405,4 @@ void Run()
 		mumbleLink.Close();
 		logger.Log(LOG_CODE::MSG, "Unloading done");
 	}
-}
+C

--- a/AUMInjector/user/main.cpp
+++ b/AUMInjector/user/main.cpp
@@ -18,7 +18,9 @@
 #include "LoggingSystem.h"
 #include "MumblePlayer.h"
 #include "GUI.h"
+#include "Input.h"
 //#include "dynamic_analysis.h"
+
 
 using namespace app;
 
@@ -52,7 +54,7 @@ void TryConnectMumble()
 void PlayerControl_FixedUpdate_Hook(PlayerControl* __this, MethodInfo* method)
 {
     PlayerControl_FixedUpdate_Trampoline(__this, method);
-    
+
     if (__this->fields.LightPrefab != nullptr)
     {
         // Cache position
@@ -130,6 +132,7 @@ void InnerNetClient_FixedUpdate_Hook(InnerNetClient* __this, MethodInfo* method)
         }
     }
 
+
     // Check if game state changed to lobby
     if (__this->fields.GameState != lastGameState)
     {
@@ -150,9 +153,33 @@ void InnerNetClient_FixedUpdate_Hook(InnerNetClient* __this, MethodInfo* method)
             // Just to be sure in case some join events were missed
             if(mumblePlayer.IsHost()) appSettings.mustBroadcast = true;
             mumblePlayer.EnterGame();
+
+
         }
     }
     lastGameState = __this->fields.GameState;
+
+    // Grab the local player off of Among Us Static variable in Player Control
+    PlayerControl* localPlayerControl = FFGALNAPKCD__TypeInfo->static_fields->LocalPlayer;
+    if (localPlayerControl) 
+    {
+        // From Player Control, get the Player Data
+        PlayerData* Data = PlayerControl_GetData(localPlayerControl, nullptr);
+        // And now we can get if we are imposter.
+        bool isImposter = Data->fields.DAPKNDBLKIA;
+        mumblePlayer.SetImposter(isImposter);
+    }
+    // Set if player is using radio
+    mumblePlayer.SetUsingRadio(inputSingleton.GetKey(appSettings.radioKey));
+
+    // Check if player is imposter and using radio
+    if (mumblePlayer.IsImposter() && mumblePlayer.IsUsingRadio())
+    {
+        logger.Log(LOG_CODE::MSG, "Imposter Radio");
+        // Move his location to DEFINED
+        mumblePlayer.SetPosX(100);
+        mumblePlayer.SetPosY(100);
+    }
 
     if (mumbleLink.linkedMem != nullptr)
     {
@@ -292,6 +319,7 @@ void InnerNetClient_HandleGameDataInner_Hook(InnerNetClient* __this, MessageRead
         }
         else
         {
+
             // Rewind reader to allow reparsing packet in trampoline
             MessageReader_set_Position(reader, pos, NULL);
         }

--- a/AUMInjector/user/settings.h
+++ b/AUMInjector/user/settings.h
@@ -95,6 +95,8 @@ class Settings
 		// Prints the sync settings to a human readable string
 		std::string HumanReadableSync();
 
+		// Player control to use Radio
+		char radioKey = 'E';
 };
 
 extern Settings appSettings;

--- a/decompile.bat
+++ b/decompile.bat
@@ -22,7 +22,7 @@ dotnet build "..\AUMDeobfuscator\AUMDeobfuscator.csproj" -c "Release"
 "..\AUMDeobfuscator\bin\Release\net5.0\AUMDeobfuscator.exe" "cs" --gameversion "%AMONGUS_VERSION%" -o "..\AUMInjector\deobfuscate\generated_%AMONGUS_VERSION%.h"
 
 CD ..
-DEL /s /q tmp\*  >NUL 2>&1
-RMDIR /s /q tmp
+#DEL /s /q tmp\*  >NUL 2>&1
+#RMDIR /s /q tmp
 
 PAUSE


### PR DESCRIPTION
Added initial Radio Imposter feature. 

Hotkey re-adjustable from ImGui settings

The implementation looks at the PlayerData from PlayerControl to determine if the local player is the imposter. If player is imposter and is pressing radio key, moves player to an offset 1999 to talk.

Also added a quick wrapper around keyboard 'A' to 'Z' input. 

A side-effect is that imposters can radio each other during meeting, but then they can't hear the meeting itself.
Another issue is that imposters won't know when the other is using the radio. Would require some RPC packets for that.

I did not use the automatic deobfuscator to find the defines in 2020_12_9s.h I didn't know what to fix or what the issue was that when I was attempting to use it it couldn't find the structure. Its a little weird since the deobfuscator already knows what PlayerControl is, but it couldn't find a certain function inside of PlayerControl.