### PR TITLE
Added precompiled headers to the project

### DIFF
--- a/AUMInjector/AUMInjector.vcxproj
+++ b/AUMInjector/AUMInjector.vcxproj
@@ -12,7 +12,14 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="framework\helpers.cpp" />
-    <ClCompile Include="framework\il2cpp-init.cpp" />
+    <ClCompile Include="framework\il2cpp-init.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </ForcedIncludeFiles>
+    </ClCompile>
+    <ClCompile Include="framework\stdafx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="gui\Blocks\AboutBlock.cpp" />
     <ClCompile Include="gui\Blocks\OverlayBlock.cpp" />
     <ClCompile Include="gui\Blocks\PlayerInfoBlock.cpp" />
@@ -57,6 +64,7 @@
     <ClInclude Include="framework\helpers.h" />
     <ClInclude Include="framework\il2cpp-appdata.h" />
     <ClInclude Include="framework\il2cpp-init.h" />
+    <ClInclude Include="framework\stdafx.h" />
     <ClInclude Include="gui\Blocks\AboutBlock.h" />
     <ClInclude Include="gui\Blocks\OverlayBlock.h" />
     <ClInclude Include="gui\Blocks\PlayerInfoBlock.h" />
@@ -168,13 +176,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>IMGUI_IMPL_WIN32_DISABLE_LINKING_XINPUT;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;WIN32;NDEBUG;AUMINJECTOR_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)appdata;$(ProjectDir)framework;$(ProjectDir)user;$(ProjectDir)gui;$(ProjectDir)gui\imgui;;$(ProjectDir)deobfuscate</AdditionalIncludeDirectories>
       <PreprocessToFile>false</PreprocessToFile>
       <DisableSpecificWarnings>4359</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>MaxSpeed</Optimization>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/AUMInjector/AUMInjector.vcxproj.filters
+++ b/AUMInjector/AUMInjector.vcxproj.filters
@@ -105,6 +105,9 @@
     <ClCompile Include="user\Input.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="framework\stdafx.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -237,6 +240,9 @@
       <Filter>Deobfuscate</Filter>
     </ClInclude>
     <ClInclude Include="user\Input.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="framework\stdafx.h">
       <Filter>Include</Filter>
     </ClInclude>
   </ItemGroup>

--- a/AUMInjector/framework/stdafx.cpp
+++ b/AUMInjector/framework/stdafx.cpp
@@ -1,0 +1,2 @@
+// STDAFX is inserted at the start of every compiled file through the VS IDE
+// No need to include stdafx.h here to compile

--- a/AUMInjector/framework/stdafx.h
+++ b/AUMInjector/framework/stdafx.h
@@ -1,0 +1,55 @@
+#pragma once
+// Stable stdafx.h file that includes minimal windows.h
+// as well as stl libs, 3rd party libs
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+
+#include <Windows.h>
+#include "imgui.h"
+#include "backends/imgui_impl_win32.h"
+#include "backends/imgui_impl_dx11.h"
+
+#include <string>
+#include <iostream>
+#include <limits>
+#include <thread>
+#include <chrono>
+#include <codecvt>
+#include <d3d11.h>
+#include <detours.h>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include <fstream>
+#include <cstdarg>
+#include <limits>
+#include <shellapi.h>
+#include <Shlwapi.h>
+#include <thread>
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <iomanip>
+#include <iterator>
+#include <locale>
+#include <map>
+#include <memory>
+#include <numeric>
+#include <set>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <atomic>
+
+
+
+#undef small
+

--- a/AUMInjector/gui/GUI.cpp
+++ b/AUMInjector/gui/GUI.cpp
@@ -22,14 +22,6 @@
 //OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //SOFTWARE.
 
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <d3d11.h>
-#include <detours.h>
-#include <vector>
-#include "imgui.h"
-#include "backends/imgui_impl_win32.h"
-#include "backends/imgui_impl_dx11.h"
 #include "D3D11Hooking.hpp"
 #include "MumblePlayer.h"
 #include "settings.h"

--- a/AUMInjector/user/LoggingSystem.cpp
+++ b/AUMInjector/user/LoggingSystem.cpp
@@ -1,6 +1,3 @@
-#include <windows.h>
-#include <iostream>
-#include <string>
 #include "helpers.h"
 #include "LoggingSystem.h"
 

--- a/AUMInjector/user/LoggingSystem.h
+++ b/AUMInjector/user/LoggingSystem.h
@@ -1,10 +1,5 @@
 #pragma once
 
-#include <string>
-#include <fstream>
-#include <iostream>
-#include <cstdarg>
-
 enum class LOG_CODE
 {
 	// Something went wrong

--- a/AUMInjector/user/MumbleLink.cpp
+++ b/AUMInjector/user/MumbleLink.cpp
@@ -1,7 +1,3 @@
-#include <Windows.h>
-#include <shellapi.h>
-#include <Shlwapi.h>
-#include <thread>
 #include "MumbleLink.h"
 #include "Settings.h"
 #include "OrderedLock.h"

--- a/AUMInjector/user/MumbleLink.h
+++ b/AUMInjector/user/MumbleLink.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <windows.h>
-#include <string>
-
 struct LinkedMem
 {
 #ifdef _WIN32

--- a/AUMInjector/user/MumblePlayer.h
+++ b/AUMInjector/user/MumblePlayer.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <limits>
 class MumblePlayer
 {
 public:

--- a/AUMInjector/user/main.cpp
+++ b/AUMInjector/user/main.cpp
@@ -1,17 +1,9 @@
 // Generated C++ file by Il2CppInspector - http://www.djkaty.com - https://github.com/djkaty
 // Custom injected code entry point
 
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <iostream>
-#include <limits>
-#include <thread>
-#include <chrono>
-#include <codecvt>
 #include "il2cpp-init.h"
 #include "il2cpp-appdata.h"
 #include "helpers.h"
-#include <detours.h>
 #include "MumbleLink.h"
 #include "deobfuscate.h"
 #include "settings.h"
@@ -20,7 +12,6 @@
 #include "GUI.h"
 #include "Input.h"
 //#include "dynamic_analysis.h"
-
 
 using namespace app;
 

--- a/AUMInjector/user/settings.cpp
+++ b/AUMInjector/user/settings.cpp
@@ -1,7 +1,3 @@
-#include <Windows.h>
-#include <string>  
-#include <iostream> 
-#include <sstream>
 #include "settings.h"
 #include "helpers.h"
 

--- a/AUMInjector/user/settings.h
+++ b/AUMInjector/user/settings.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <string>
 #include "CLI11.hpp"
 #include "LoggingSystem.h"
 

--- a/AUMInjector/user/winhttp.cpp
+++ b/AUMInjector/user/winhttp.cpp
@@ -1,5 +1,3 @@
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
 #include "main.h"
 
 // DLL proxy definitions


### PR DESCRIPTION
Issue #67 and #48

Added precompiled header to the game. VS IDE will auto include stdafx.h before any .cpp files are compiled.

I had to disable the precompiled header and the auto-include for il2cpp-init.cpp due to a name clash between windows.h and a lot of I<something> (c# interfaces?) il2cpp-init.cpp defines. Not exactly sure what it is, but I think its probably a definition carryover from unity compiling.

Currently the PCH contains the STL libs, ImGui, and Windows.h.