### PR TITLE
Game data wrappers and dev tool build configurations w/ positional radar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ mono_crash.*
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+[Rr]elWithDevTools/
 x64/
 x86/
 [Ww][Ii][Nn]32/
@@ -370,3 +371,4 @@ Il2CppInspector*
 
 setup.bat
 Scripts
+RelWithDevTools/

--- a/AUMDeobfuscator/AUMDeobfuscator.csproj
+++ b/AUMDeobfuscator/AUMDeobfuscator.csproj
@@ -11,6 +11,7 @@
         <Authors>LelouBil</Authors>
         <Company>AUMDeobfuscator</Company>
         <Product>AUMDeobfuscator</Product>
+        <Configurations>Debug;Release;RelWithDevTools</Configurations>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -18,6 +19,10 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+      <PlatformTarget>AnyCPU</PlatformTarget>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)'=='RelWithDevTools'">
       <PlatformTarget>AnyCPU</PlatformTarget>
     </PropertyGroup>
 

--- a/AUMDeobfuscator/MatcherDefinitions.cs
+++ b/AUMDeobfuscator/MatcherDefinitions.cs
@@ -46,19 +46,153 @@ namespace AUMDeobfuscator
                     .OfName("MaxReportDistance")
                     .WithNamedType("float")
                     .And()
+                    .WithField()
+                    .WithTag("_cachedData")
+                    .And()
                     .WithMethod(FixedUpdate)
                     .And()
                     .WithMethod(GetTruePosition)
                     .And()
                     .WithMethod(Die)
                     .And();
-
-
         }
+
+        public static class Palette
+		{
+            public static readonly ClassMatch ClassPlayerControl =
+                new ClassMatch()
+                    .WithTag("Palette")
+                    .WithField()
+                    .WithTag("DisabledGrey")
+                    .WithNamedType("Color")
+                    .And()
+                    .WithField()
+                    .WithTag("Black")
+                    .WithNamedType("Color")
+                    .And()
+                    .WithField()
+                    .WithTag("LightBlue")
+                    .WithNamedType("Color")
+                    .And()
+                    .WithField()
+                    .WithNamedType("Color32")
+                    .WithTag("VisorColor")
+                    .And();
+		}
+
+		public static class GameData
+		{
+            public static readonly MethodMatch GetPlayerById =
+                new MethodMatch(null!)
+                    .WithTag("GetPlayerById")
+                    .OfName("GetPlayerById");
+
+            public static readonly MethodMatch UpdateColor =
+                new MethodMatch(null!)
+                    .WithTag("UpdateColor")
+                    .OfName("UpdateColor")
+                    .WithNumberOfParameters(2);
+
+            public static readonly MethodMatch HandleDisconnect =
+                new MethodMatch(null!)
+                    .WithTag("HandleDisconnect")
+                    .OfName("HandleDisconnect")
+                    .WithNumberOfParameters(2);
+
+            public static readonly MethodMatch CompleteTask =
+                new MethodMatch(null!)
+                    .WithTag("CompleteTask")
+                    .OfName("CompleteTask")
+                    .WithNumberOfParameters(2);
+
+            public static readonly MethodMatch Awake =
+                new MethodMatch(null!)
+                    .WithTag("Awake")
+                    .OfName("Awake")
+                    .WithNumberOfParameters(0);
+
+            public static readonly ClassMatch ClassGameData =
+                new ClassMatch()
+                    .WithTag("GameData")
+                    .OfSuperClass(new ClassMatch().WithTag("InnerNetObject"))
+                    .WithField()
+                    .WithTag("CompletedTasks")
+                    .WithNamedType("int")
+                    .And()
+                    .WithField()
+                    .WithTag("TotalTasks")
+                    .WithNamedType("int")
+                    .And()
+                    .WithMethod(GetPlayerById)
+                    .And()
+                    .WithMethod(HandleDisconnect)
+                    .And()
+                    .WithMethod(CompleteTask)
+                    .And()
+                    .WithMethod(Awake)
+                    .And()
+                    .WithMethod(UpdateColor)
+                    .And();
+        }
+
+        public static class PlayerInfo
+        {
+            public static readonly MethodMatch FindTaskById =
+                new MethodMatch(null!)
+                    .WithTag("FindTaskById")
+                    .WithModifier("public")
+                    .WithNumberOfParameters(1)
+                    .WithParameter()
+                    .WithNamedType("uint").And();
+
+            public static readonly MethodMatch Deserialize =
+                new MethodMatch(null!)
+                    .WithTag("Deserialize")
+                    .WithModifier("public")
+                    .WithNumberOfParameters(1)
+                    .WithParameter()
+                    .WithNamedType("MessageReader").And();
+
+            public static readonly MethodMatch Serialize =
+                new MethodMatch(null!)
+                    .WithTag("Serialize")
+                    .WithModifier("public")
+                    .WithNumberOfParameters(1)
+                    .WithParameter()
+                    .WithNamedType("MessageWriter").And();
+
+            public static readonly ClassMatch ClassPlayerInfo =
+                new ClassMatch()
+                    .WithTag("PlayerInfo")
+                    .WithField()
+                    .WithNamedType("byte")
+                    .And()
+                    .WithField()
+                    .WithNamedType("bool")
+                    .And()
+                    .WithField()
+                    .WithNamedType("string")
+                    .And()
+                    .WithField()
+                    .WithNamedType("uint")
+                    .And()
+                    .WithMethod(FindTaskById)
+                    .And()
+                    .WithMethod(Deserialize)
+                    .And()
+                    .WithMethod(Serialize)
+					.And();
+
+            public static readonly FieldMatch FieldColorId =
+                new FieldMatch(ClassPlayerInfo)
+                    .WithTag("ColorId")
+                    .WithNamedType("byte");
+        }
+
+
 
         public static class InnerNetClient
         {
-
             public static readonly EnumValueMatch Joined = 
                 new EnumValueMatch(null!)
                     .OfName("Joined")
@@ -257,8 +391,6 @@ namespace AUMDeobfuscator
                     .And()
                     .WithMethod(AddChat)
                     .And();
-            
-            
         }
 
         public static class AmongUsClient

--- a/AUMDeobfuscator/Matchers/FieldMatch.cs
+++ b/AUMDeobfuscator/Matchers/FieldMatch.cs
@@ -33,5 +33,12 @@ namespace AUMDeobfuscator.Matchers
             AddPred($"name : {name}",f => f.Declaration.Variables[0].Identifier.ToString() == name);
             return this;
         }
+
+        public FieldMatch OfNameContains(string contains)
+        {
+            AddPred($"name contains : {contains}",f => f.Declaration.Variables[0].Identifier.ToString().Contains(contains));
+            return this;
+        }
+
     }
 }

--- a/AUMInjector/AUMInjector.vcxproj
+++ b/AUMInjector/AUMInjector.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="RelWithDevTools|Win32">
+      <Configuration>RelWithDevTools</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -11,18 +15,28 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="deobfuscate\2020_12_9s.cpp" />
     <ClCompile Include="framework\helpers.cpp" />
     <ClCompile Include="framework\il2cpp-init.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDevTools|Win32'">NotUsing</PrecompiledHeader>
       <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='RelWithDevTools|Win32'">
+      </ForcedIncludeFiles>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
       </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="framework\stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='RelWithDevTools|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="gui\Blocks\AboutBlock.cpp" />
     <ClCompile Include="gui\Blocks\OverlayBlock.cpp" />
     <ClCompile Include="gui\Blocks\PlayerInfoBlock.cpp" />
+    <ClCompile Include="gui\Blocks\PositionRadarBlock.cpp" />
     <ClCompile Include="gui\Blocks\SettingsBlock.cpp" />
     <ClCompile Include="gui\D3D11Hooking.cpp" />
     <ClCompile Include="gui\GUI.cpp" />
@@ -34,6 +48,7 @@
     <ClCompile Include="gui\imgui\imgui_demo.cpp" />
     <ClCompile Include="gui\imgui\imgui_draw.cpp" />
     <ClCompile Include="gui\imgui\imgui_widgets.cpp" />
+    <ClCompile Include="user\GameData.cpp" />
     <ClCompile Include="user\Input.cpp" />
     <ClCompile Include="user\LoggingSystem.cpp" />
     <ClCompile Include="user\MumbleLink.cpp" />
@@ -68,6 +83,7 @@
     <ClInclude Include="gui\Blocks\AboutBlock.h" />
     <ClInclude Include="gui\Blocks\OverlayBlock.h" />
     <ClInclude Include="gui\Blocks\PlayerInfoBlock.h" />
+    <ClInclude Include="gui\Blocks\PositionRadarBlock.h" />
     <ClInclude Include="gui\Blocks\SettingsBlock.h" />
     <ClInclude Include="gui\D3D11Hooking.hpp" />
     <ClInclude Include="gui\GUI.h" />
@@ -83,6 +99,7 @@
     <ClInclude Include="gui\imgui\imstb_truetype.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="user\CLI11.hpp" />
+    <ClInclude Include="user\GameData.h" />
     <ClInclude Include="user\Input.h" />
     <ClInclude Include="user\LoggingSystem.h" />
     <ClInclude Include="user\MumbleLink.h" />
@@ -117,6 +134,13 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDevTools|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -126,6 +150,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDevTools|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -139,17 +166,24 @@
     <TargetName>winhttp</TargetName>
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDevTools|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <TargetName>winhttp</TargetName>
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>IMGUI_IMPL_WIN32_DISABLE_LINKING_XINPUT;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;WIN32;_DEBUG;AUMINJECTOR_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DEV_TOOLS;IMGUI_IMPL_WIN32_DISABLE_LINKING_XINPUT;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;WIN32;_DEBUG;AUMINJECTOR_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)appdata;$(ProjectDir)framework;$(ProjectDir)user;$(ProjectDir)gui;$(ProjectDir)gui\imgui;;$(ProjectDir)deobfuscate</AdditionalIncludeDirectories>
       <PreprocessToFile>false</PreprocessToFile>
       <DisableSpecificWarnings>4359</DisableSpecificWarnings>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -158,7 +192,7 @@
       <ModuleDefinitionFile>user\winhttp.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>$(ProjectDir)..\vmupload.bat</Command>
+      <Command>$(ProjectDir)..\vmupload.bat $(OutDir)\winhttp.dll</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy to Steam and VMs</Message>
@@ -194,7 +228,43 @@
       <ModuleDefinitionFile>user\winhttp.def</ModuleDefinitionFile>
     </Link>
     <PostBuildEvent>
-      <Command>$(ProjectDir)..\vmupload.bat</Command>
+      <Command>$(ProjectDir)..\vmupload.bat $(OutDir)\winhttp.dll</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>Copy to Steam and VMs</Message>
+    </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>
+      </Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDevTools|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>DEV_TOOLS;IMGUI_IMPL_WIN32_DISABLE_LINKING_XINPUT;IMGUI_IMPL_WIN32_DISABLE_GAMEPAD;WIN32;NDEBUG;AUMINJECTOR_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(ProjectDir)appdata;$(ProjectDir)framework;$(ProjectDir)user;$(ProjectDir)gui;$(ProjectDir)gui\imgui;;$(ProjectDir)deobfuscate</AdditionalIncludeDirectories>
+      <PreprocessToFile>false</PreprocessToFile>
+      <DisableSpecificWarnings>4359</DisableSpecificWarnings>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <Optimization>MaxSpeed</Optimization>
+      <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <ModuleDefinitionFile>user\winhttp.def</ModuleDefinitionFile>
+    </Link>
+    <PostBuildEvent>
+      <Command>$(ProjectDir)..\vmupload.bat $(OutDir)\winhttp.dll</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Copy to Steam and VMs</Message>

--- a/AUMInjector/AUMInjector.vcxproj.filters
+++ b/AUMInjector/AUMInjector.vcxproj.filters
@@ -108,6 +108,15 @@
     <ClCompile Include="framework\stdafx.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="user\GameData.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="gui\Blocks\PositionRadarBlock.cpp">
+      <Filter>GUI\Blocks</Filter>
+    </ClCompile>
+    <ClCompile Include="deobfuscate\2020_12_9s.cpp">
+      <Filter>Deobfuscate</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -244,6 +253,12 @@
     </ClInclude>
     <ClInclude Include="framework\stdafx.h">
       <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="user\GameData.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="gui\Blocks\PositionRadarBlock.h">
+      <Filter>GUI\Blocks</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/AUMInjector/deobfuscate/2020_12_9s.cpp
+++ b/AUMInjector/deobfuscate/2020_12_9s.cpp
@@ -1,0 +1,9 @@
+#include <deobfuscate.h>
+
+// Definitions here to avoid duplicate defines
+#if GAME_VERSION == GAME_VERSION_2020_12_9s
+InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Joined = KHNHJFFECBP_KGEKNMMAKKN__Enum_Joined;
+InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Started = KHNHJFFECBP_KGEKNMMAKKN__Enum_Started;
+InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended = KHNHJFFECBP_KGEKNMMAKKN__Enum_Ended;
+bool EGLJNOMOGNP_DCJMABDDJCF__Fields::*IsImposter = &EGLJNOMOGNP_DCJMABDDJCF__Fields::DAPKNDBLKIA;
+#endif

--- a/AUMInjector/deobfuscate/2020_12_9s.h
+++ b/AUMInjector/deobfuscate/2020_12_9s.h
@@ -1,6 +1,17 @@
 using Player_Die_Reason__Enum = DBLJKMDLJIF__Enum;
 using PlayerControl = FFGALNAPKCD;
+#define PlayerControl__TypeInfo FFGALNAPKCD__TypeInfo
+using GameData = EGLJNOMOGNP;
+using Palette = LOCPGOACAJF;
+#define Palette__TypeInfo LOCPGOACAJF__TypeInfo
+#define PlayerColors OPKIKLENHFA
+using PlayerInfo = EGLJNOMOGNP_DCJMABDDJCF;
+
+// Part of PlayerInfo
+#define ColorId EHAHBDFODKC 
+
 using InnerNetClient = KHNHJFFECBP;
+
 using InnerNetClient_GameState__Enum = KHNHJFFECBP_KGEKNMMAKKN__Enum;
 using InnerNet_DisconnectReasons__Enum = GHMBCKNECJF__Enum;
 using MeetingHud = OOCJALPKPEP;
@@ -8,13 +19,27 @@ using HqHudOverrideTask = NIAFLKKACLE;
 using HudOverrideTask = LFOILEODBMA;
 using ChatController = GEHKHGLKFHE;
 using AmongUsClient = FMLLKEACGIO;
+extern InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Joined;
+extern InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Started;
+extern InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended;
 using PlayerData = EGLJNOMOGNP_DCJMABDDJCF;
-InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Joined = KHNHJFFECBP_KGEKNMMAKKN__Enum_Joined;
-InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Started = KHNHJFFECBP_KGEKNMMAKKN__Enum_Started;
-InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended = KHNHJFFECBP_KGEKNMMAKKN__Enum_Ended;
 #define PlayerControl_GetTruePosition_Trampoline FFGALNAPKCD_GetTruePosition
 #define PlayerControl_Die_Trampoline FFGALNAPKCD_Die
+#define PlayerControl_GetData_Trampoline FFGALNAPKCD_get_Data
 #define PlayerControl_FixedUpdate_Trampoline FFGALNAPKCD_FixedUpdate
+
+// Externs for definitions in cpp
+extern InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Joined;
+extern InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Started;
+extern InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended;
+extern bool EGLJNOMOGNP_DCJMABDDJCF__Fields::* IsImposter;
+
+#define GameData_Awake_Trampoline EGLJNOMOGNP_Awake
+#define GameData_GetPlayerById_Trampoline EGLJNOMOGNP_GetPlayerById
+#define GameData_UpdateColor_Trampoline EGLJNOMOGNP_UpdateColor
+#define GameData_GetPlayerCount_Trampoline EGLJNOMOGNP_get_PlayerCount
+#define GameData_HandleDisconnect_Trampoline EGLJNOMOGNP_HandleDisconnect
+#define GameData_CompleteTask_Trampoline EGLJNOMOGNP_CompleteTask
 #define InnerNetClient_FixedUpdate_Trampoline KHNHJFFECBP_FixedUpdate
 #define InnerNetClient_Disconnect_Trampoline KHNHJFFECBP_AMKMODDAFOO
 #define InnerNetClient_HandleGameDataInner_Trampoline KHNHJFFECBP_LMFMFBMONOO
@@ -29,4 +54,4 @@ InnerNetClient_GameState__Enum InnerNetClient_GameState__Enum_Ended = KHNHJFFECB
 #define MessageWriter_Write_Byte_Trampoline MessageWriter_Write_1
 #define AmongUsClient_OnPlayerJoined_Trampoline FMLLKEACGIO_BIEPKGFMACN
 #define PlayerControl_GetData_Trampoline FFGALNAPKCD_get_Data
-bool EGLJNOMOGNP_DCJMABDDJCF__Fields::*IsImposter = &EGLJNOMOGNP_DCJMABDDJCF__Fields::DAPKNDBLKIA;
+#define PlayerInfo_GetPlayerObject_Trampoline EGLJNOMOGNP_DCJMABDDJCF_FHOELMJAPIC

--- a/AUMInjector/framework/stdafx.h
+++ b/AUMInjector/framework/stdafx.h
@@ -37,6 +37,8 @@
 #include <iterator>
 #include <locale>
 #include <map>
+#include <unordered_map>
+#include <unordered_set>
 #include <memory>
 #include <numeric>
 #include <set>

--- a/AUMInjector/gui/Blocks/PositionRadarBlock.cpp
+++ b/AUMInjector/gui/Blocks/PositionRadarBlock.cpp
@@ -1,0 +1,87 @@
+#ifdef DEV_TOOLS
+
+// Output position / color data to ImGui
+#include "PositionRadarBlock.h"
+#include "GameData.h"
+#include "imgui.h"
+#include "MumblePlayer.h"
+
+constexpr float size = 10.0f;
+
+ImVec4& NormalizeColor(ImVec4& color)
+{
+    color.x /= 255.0f;
+    color.y /= 255.0f;
+    color.z /= 255.0f;
+    color.w /= 255.0f;
+    return color;
+}
+
+PositionRadarBlock::PositionRadarBlock() {}
+
+#define V2 ImVec2
+void FX(ImDrawList* d, V2 a, V2 b, V2 sz, AUM::Vec2 playerPos)
+{
+    // for (int n = 0; n < (1.0f + sinf(t * 5.7f)) * 40.0f; n++)
+    //     d->AddCircle(V2(a.x + sz.x * 0.5f, a.y + sz.y * 0.5f), sz.y * (0.01f + n * 0.03f),
+    //         IM_COL32(255, 140 - n * 4, n * 3, 255));
+
+    const ImVec2 centerCanvas(a.x + sz.x * 0.5f, a.y + sz.y * 0.5f);
+    int playerNetID = mumblePlayer.GetNetID();
+
+    auto playerColor = AUM::Game::GetColor(playerNetID);
+    ImVec4 playerDrawColor = ImVec4(playerColor.r, playerColor.g, playerColor.b, playerColor.a);
+
+    d->AddCircle(centerCanvas, size / 3, 
+        (ImColor)NormalizeColor(playerDrawColor), 
+        0, size / 2);
+
+    auto controls = AUM::Game::GetControls();
+
+    // For each player control, get position and color
+	for (const auto& control : controls)
+	{
+        int netID = control->fields._.NetId;
+		if (netID == playerNetID) continue;
+
+		// Center the radar
+		auto pos = AUM::Game::GetPosition(control);
+		auto diffX = (pos.x - playerPos.x) * 5.0f;
+		auto diffY = (pos.y - playerPos.y) * 5.0f;
+
+		ImVec2 canvasPosition(centerCanvas.x + diffX, centerCanvas.y - diffY);
+
+		auto color = AUM::Game::GetColor(control);
+		ImVec4 drawColor = ImVec4(color.r, color.g, color.b, color.a);
+
+		d->AddCircle(canvasPosition, size / 2, (ImColor)NormalizeColor(drawColor), 0, size / 4);
+	}
+}
+
+void PositionRadarBlock::Update()
+{
+    ImGuiIO& io = ImGui::GetIO();
+    ImVec2 size(ImGui::GetWindowSize());
+    // Offset for the borders of the window because size of canvas
+	// is less than size of window
+    size.x -= 20.0f;
+    size.y -= 40.0f;
+    // This makes the canvas
+    ImGui::InvisibleButton("canvas", size);
+    // Get canvas boundaries
+    ImVec2 p0 = ImGui::GetItemRectMin();
+    ImVec2 p1 = ImGui::GetItemRectMax();
+    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    draw_list->PushClipRect(p0, p1);
+
+    ImVec4 mouse_data;
+    mouse_data.x = (io.MousePos.x - p0.x) / size.x;
+    mouse_data.y = (io.MousePos.y - p0.y) / size.y;
+    mouse_data.z = io.MouseDownDuration[0];
+    mouse_data.w = io.MouseDownDuration[1];
+
+    FX(draw_list, p0, p1, size, { mumblePlayer.posCache[0], mumblePlayer.posCache[1] });
+    draw_list->PopClipRect();
+}
+
+#endif

--- a/AUMInjector/gui/Blocks/PositionRadarBlock.h
+++ b/AUMInjector/gui/Blocks/PositionRadarBlock.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef DEV_TOOLS
+#include "GUIBlock.h"
+
+struct ImVec2;
+struct ImVec4;
+struct ImDrawList;
+
+class PositionRadarBlock : public GUIBlock
+{
+public:
+	PositionRadarBlock();
+
+	void Update() override;
+};
+
+#endif
+

--- a/AUMInjector/gui/GUI.cpp
+++ b/AUMInjector/gui/GUI.cpp
@@ -28,6 +28,7 @@
 #include "GUI.h"
 #include "GUIWindow.h"
 #include "Blocks/PlayerInfoBlock.h"
+#include "Blocks/PositionRadarBlock.h"
 #include "Blocks/SettingsBlock.h"
 #include "Blocks/OverlayBlock.h"
 #include "Blocks/AboutBlock.h"
@@ -175,6 +176,13 @@ HRESULT __stdcall D3D_FUNCTION_HOOK(IDXGISwapChain* pThis, UINT SyncInterval, UI
         GUIWindow* window2 = new GUIWindow("Proximity Configuration", 0);
         window2->AddBlock(new SettingsBlock());
         GUIWindows.emplace_back(window2);
+
+#ifdef DEV_TOOLS
+		GUIWindow* window3 = new GUIWindow("Positional Radar", 0);
+        window3->AddBlock(new PositionRadarBlock());
+        GUIWindows.emplace_back(window3);
+#endif
+
 
         overlayWindow = new GUIWindow("Overlay", ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
             ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove);

--- a/AUMInjector/user/GameData.cpp
+++ b/AUMInjector/user/GameData.cpp
@@ -1,0 +1,92 @@
+#include "deobfuscate.h"
+#include "GameData.h"
+
+
+namespace AUM
+{
+	GameData* Game::_gameData = nullptr;
+
+	void Game::SetGameData(GameData* gameData)
+	{
+		_gameData = gameData;
+	}
+
+	GameData* Game::GetGameData()
+	{
+		return _gameData;
+	}
+
+	PlayerControl* Game::GetPlayerControl(int netID)
+	{
+		auto controls = GetControls();
+
+		auto iter = std::find_if(controls.begin(), controls.end(),
+			[netID](PlayerControl* ctrl) -> bool
+		{
+			return ctrl->fields._.NetId == (uint32_t)netID;
+		});
+
+		// Does not exist 
+		if (iter == controls.end())
+			return nullptr;
+
+		return *iter;
+	}
+
+
+	Color Game::GetColor(PlayerControl* control)
+	{
+		// Get the player info 
+		PlayerInfo* info = PlayerControl_GetData_Trampoline(control, NULL);
+		// Color array not aligned correctly per il2cpp, is 4 byte aligned not 8 byte
+		app::Color32* colorArr = (Palette__TypeInfo->static_fields->PlayerColors->vector);
+		// Convert to 8 bit * 4 structure to fix alignment
+		uint8_t* color = (reinterpret_cast<uint8_t*>(colorArr) + info->fields.ColorId * 4);
+
+		return  { color[0], color[1], color[2], color[3] };
+	}
+
+
+	Color Game::GetColor(int netID) 
+	{
+		auto control = GetPlayerControl(netID);
+		if (!control) return { 0, 0, 0, 0 };
+
+		return GetColor(control);
+	}
+
+	Vec2 Game::GetPosition(PlayerControl* control)
+	{
+		Vector2 pos = PlayerControl_GetTruePosition_Trampoline(control, NULL);
+		return { pos.x, pos.y };
+	}
+
+	Vec2 Game::GetPosition(int netID)
+	{
+		auto control = GetPlayerControl(netID);
+		if (!control) return { 0.0f, 0.0f };
+
+		return GetPosition(control);
+	}
+
+	std::vector<PlayerControl*> Game::GetControls()
+	{
+		// Get all current PlayerControls found in the game
+		std::vector<PlayerControl*> result;
+		ArrayList* controlList = reinterpret_cast<ArrayList*>(PlayerControl__TypeInfo->static_fields->AllPlayerControls);
+		int count = ArrayList_get_Count(
+			controlList,
+			NULL);
+
+		if (count == 0) return result;
+
+		for (int i = 0; i < count; ++i)
+		{
+			result.push_back(reinterpret_cast<PlayerControl*>(ArrayList_get_Item(controlList, i, NULL)));
+		}
+
+
+		return result;
+	}
+}
+

--- a/AUMInjector/user/GameData.h
+++ b/AUMInjector/user/GameData.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <deobfuscate.h>
+
+// Custom definitions for our game state and other data
+namespace AUM
+{
+	struct Vec2
+	{
+		float x, y;
+	};
+
+	// 0 to 255
+	struct Color
+	{
+		uint8_t r, g, b, a;
+	};
+
+	class Game
+	{
+	public:
+		static void SetGameData(GameData* gameData);
+		static GameData* GetGameData();
+
+		// Get most recent player control from net ID
+		static PlayerControl* GetPlayerControl(int netID);
+		// Get current list of player controls in game
+		static std::vector<PlayerControl*> GetControls();
+
+		// Get color from existing player control
+		static Color GetColor(PlayerControl* control);
+		// Get updated player control from Net ID and then grab color
+		static Color GetColor(int netID);
+		// Get position from existing player control
+		static Vec2 GetPosition(PlayerControl* control);
+		// Get updated player control from Net ID and then grab position
+		static Vec2 GetPosition(int netID);
+
+	private:
+		static GameData* _gameData;
+	};
+}
+

--- a/AUMInjector/user/MumblePlayer.h
+++ b/AUMInjector/user/MumblePlayer.h
@@ -139,6 +139,9 @@ private:
 
 	// Reads private information to display it to the user
 	friend class PlayerInfoBlock;
+#ifdef DEV_TOOLS
+	friend class PositionRadarBlock;
+#endif
 };
 
 extern MumblePlayer mumblePlayer;

--- a/AmongUs-Mumble.sln
+++ b/AmongUs-Mumble.sln
@@ -15,6 +15,8 @@ Global
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
+		RelWithDevTools|Any CPU = RelWithDevTools|Any CPU
+		RelWithDevTools|x86 = RelWithDevTools|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5A9DF862-B3B4-4125-A7C0-7F1058EC33E6}.Debug|Any CPU.ActiveCfg = Debug|Win32
@@ -23,6 +25,9 @@ Global
 		{5A9DF862-B3B4-4125-A7C0-7F1058EC33E6}.Release|Any CPU.ActiveCfg = Release|Win32
 		{5A9DF862-B3B4-4125-A7C0-7F1058EC33E6}.Release|x86.ActiveCfg = Release|Win32
 		{5A9DF862-B3B4-4125-A7C0-7F1058EC33E6}.Release|x86.Build.0 = Release|Win32
+		{5A9DF862-B3B4-4125-A7C0-7F1058EC33E6}.RelWithDevTools|Any CPU.ActiveCfg = RelWithDevTools|Win32
+		{5A9DF862-B3B4-4125-A7C0-7F1058EC33E6}.RelWithDevTools|x86.ActiveCfg = Release|Win32
+		{5A9DF862-B3B4-4125-A7C0-7F1058EC33E6}.RelWithDevTools|x86.Build.0 = Release|Win32
 		{B77105A4-61C7-431A-AD42-57CE628358B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B77105A4-61C7-431A-AD42-57CE628358B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B77105A4-61C7-431A-AD42-57CE628358B9}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -31,6 +36,10 @@ Global
 		{B77105A4-61C7-431A-AD42-57CE628358B9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B77105A4-61C7-431A-AD42-57CE628358B9}.Release|x86.ActiveCfg = Release|Any CPU
 		{B77105A4-61C7-431A-AD42-57CE628358B9}.Release|x86.Build.0 = Release|Any CPU
+		{B77105A4-61C7-431A-AD42-57CE628358B9}.RelWithDevTools|Any CPU.ActiveCfg = Release|Any CPU
+		{B77105A4-61C7-431A-AD42-57CE628358B9}.RelWithDevTools|Any CPU.Build.0 = Release|Any CPU
+		{B77105A4-61C7-431A-AD42-57CE628358B9}.RelWithDevTools|x86.ActiveCfg = Release|Any CPU
+		{B77105A4-61C7-431A-AD42-57CE628358B9}.RelWithDevTools|x86.Build.0 = Release|Any CPU
 		{7077482C-431B-4BEB-A521-DA5952AE3D16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7077482C-431B-4BEB-A521-DA5952AE3D16}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7077482C-431B-4BEB-A521-DA5952AE3D16}.Debug|x86.ActiveCfg = Debug|Any CPU
@@ -39,6 +48,10 @@ Global
 		{7077482C-431B-4BEB-A521-DA5952AE3D16}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7077482C-431B-4BEB-A521-DA5952AE3D16}.Release|x86.ActiveCfg = Release|Any CPU
 		{7077482C-431B-4BEB-A521-DA5952AE3D16}.Release|x86.Build.0 = Release|Any CPU
+		{7077482C-431B-4BEB-A521-DA5952AE3D16}.RelWithDevTools|Any CPU.ActiveCfg = Release|Any CPU
+		{7077482C-431B-4BEB-A521-DA5952AE3D16}.RelWithDevTools|Any CPU.Build.0 = Release|Any CPU
+		{7077482C-431B-4BEB-A521-DA5952AE3D16}.RelWithDevTools|x86.ActiveCfg = Release|Any CPU
+		{7077482C-431B-4BEB-A521-DA5952AE3D16}.RelWithDevTools|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vmupload.bat
+++ b/vmupload.bat
@@ -4,11 +4,11 @@ CD /D "%~dp0"
 CALL setup.bat
 
 ECHO "Copying to %AMONGUS%"
-COPY /b /v /y ".\Release\winhttp.dll" "%AMONGUS%\winhttp.dll"
+COPY /b /v /y "%1" "%AMONGUS%\winhttp.dll"
 
 IF DEFINED VM_UPLOAD (
     FOR %%x IN (%VM_SUFFIXES%) DO (
         ECHO "Copying to VM %VM_BASENAME%%%x"
-        COPY /b /v /y ".\Release\winhttp.dll" "\\%VM_BASENAME%%%x\%VM_AMONGUS%\winhttp.dll"
+        COPY /b /v /y "%1" "\\%VM_BASENAME%%%x\%VM_AMONGUS%\winhttp.dll"
     )
 )


### PR DESCRIPTION
This is primarily a feature push that was a long time coming.

Includes:

- Game data containers. Found in GameData.h/cpp, these are used to query PlayerControl/PlayerInfo for internal data and are not reliant on RPC packets at any stage. 
- Dev tool build configurations. Called **RelWithDevTools**, this provides the preprocessor definition of 'DEV_TOOLS', otherwise being identical to the release build. This allows us to build with debugging features that'd typically be unavailable to the end-user. The build configurations have been updated to post-build dump **their** winhttp.dll to the Among Us steam folder, as opposed to strictly the Release variant.
- Positional Radar dev tool, integrated into ImGui. This still needs some work for ghost mode and the render can be improved by walls and such. 
-  The functions for the above features (along with some deprecated ones that I left in case anybody needed them) have been included in the deobfuscation header, and some have been added to the MatcherDefinitions cs file for scalability where possible. The deobfuscation header now also has a newly created CPP file for its definitions, as to avoid redefinition errors if referenced in multiple areas. 