### PR TITLE
Only imposters can use radio

### DIFF
--- a/AUMInjector/user/MumblePlayer.cpp
+++ b/AUMInjector/user/MumblePlayer.cpp
@@ -185,7 +185,7 @@ void MumblePlayer::SetPos(int i, float pos)
             posCache[i] = pos;
         }
     } 
-    if (this->isUsingRadio) // If you're using radio, go away. (If people think meeting radio is a bug, we'll change it)
+    if (this->isUsingRadio && this->isImposter) // If you're using radio, go away. (If people think meeting radio is a bug, we'll change it)
     {
         posCache[i] = radioOffset;
     }


### PR DESCRIPTION
As of right now you will get teleported to the radioOffset no matter if you are imposter or not and press the radio button. This small change will ensure that only imposters get moved there