### PR TITLE
Add Imposter Radio Visualization

### DIFF
--- a/AUMInjector/AUMInjector.vcxproj
+++ b/AUMInjector/AUMInjector.vcxproj
@@ -36,6 +36,7 @@
     <ClCompile Include="gui\Blocks\OverlayBlock.cpp" />
     <ClCompile Include="gui\Blocks\PlayerInfoBlock.cpp" />
     <ClCompile Include="gui\Blocks\PositionRadarBlock.cpp" />
+    <ClCompile Include="gui\Blocks\RadioSignalBlock.cpp" />
     <ClCompile Include="gui\Blocks\SettingsBlock.cpp" />
     <ClCompile Include="gui\D3D11Hooking.cpp" />
     <ClCompile Include="gui\GUI.cpp" />
@@ -83,6 +84,7 @@
     <ClInclude Include="gui\Blocks\OverlayBlock.h" />
     <ClInclude Include="gui\Blocks\PlayerInfoBlock.h" />
     <ClInclude Include="gui\Blocks\PositionRadarBlock.h" />
+    <ClInclude Include="gui\Blocks\RadioSignalBlock.h" />
     <ClInclude Include="gui\Blocks\SettingsBlock.h" />
     <ClInclude Include="gui\D3D11Hooking.hpp" />
     <ClInclude Include="gui\GUI.h" />

--- a/AUMInjector/AUMInjector.vcxproj.filters
+++ b/AUMInjector/AUMInjector.vcxproj.filters
@@ -114,6 +114,9 @@
     <ClCompile Include="gui\Blocks\PositionRadarBlock.cpp">
       <Filter>GUI\Blocks</Filter>
     </ClCompile>
+    <ClCompile Include="gui\Blocks\RadioSignalBlock.cpp">
+      <Filter>GUI\Blocks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -255,6 +258,9 @@
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="gui\Blocks\PositionRadarBlock.h">
+      <Filter>GUI\Blocks</Filter>
+    </ClInclude>
+    <ClInclude Include="gui\Blocks\RadioSignalBlock.h">
       <Filter>GUI\Blocks</Filter>
     </ClInclude>
   </ItemGroup>

--- a/AUMInjector/gui/Blocks/RadioSignalBlock.cpp
+++ b/AUMInjector/gui/Blocks/RadioSignalBlock.cpp
@@ -1,0 +1,31 @@
+#include "RadioSignalBlock.h"
+#include "imgui.h"
+#include "MumblePlayer.h"
+
+RadioSignalBlock::RadioSignalBlock() {}
+
+void RadioSignalBlock::Update()
+{
+    ImGuiIO& io = ImGui::GetIO();
+    ImVec2 size(ImGui::GetWindowSize());
+    // Offset for the borders of the window because size of canvas
+    // is less than size of window
+    size.x -= 20.0f;
+    size.y -= 20.0f;
+    // This makes the canvas
+    ImGui::InvisibleButton("canvas", size);
+    // Get canvas boundaries
+    ImVec2 p0 = ImGui::GetItemRectMin();
+    ImVec2 p1 = ImGui::GetItemRectMax();
+    ImDrawList* draw_list = ImGui::GetWindowDrawList();
+    draw_list->PushClipRect(p0, p1);
+    if(mumblePlayer.IsRadioInUse()) {
+        // Draw a green square when radio is not in use
+        draw_list->AddRectFilled(p0, p1, IM_COL32(0, 255, 0, 255));
+    }
+    else {
+        // Draw a red square when radio is not in use
+        draw_list->AddRectFilled(p0, p1, IM_COL32(255, 0, 0, 255));
+    }
+    draw_list->PopClipRect();
+}

--- a/AUMInjector/gui/Blocks/RadioSignalBlock.h
+++ b/AUMInjector/gui/Blocks/RadioSignalBlock.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "GUIBlock.h"
+
+class RadioSignalBlock : public GUIBlock
+{
+public:
+	RadioSignalBlock();
+
+	void Update() override;
+
+};
+

--- a/AUMInjector/gui/GUI.cpp
+++ b/AUMInjector/gui/GUI.cpp
@@ -32,6 +32,7 @@
 #include "Blocks/SettingsBlock.h"
 #include "Blocks/OverlayBlock.h"
 #include "Blocks/AboutBlock.h"
+#include "Blocks/RadioSignalBlock.h"
 #include "Input.h"
 
 IDXGISwapChain* SwapChain;
@@ -50,6 +51,7 @@ HWND window;
 
 std::vector<GUIWindow*> GUIWindows;
 GUIWindow* overlayWindow;
+GUIWindow* imposterRadioWindow;
 
 LRESULT CALLBACK WndProcHook(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
@@ -177,6 +179,8 @@ HRESULT __stdcall D3D_FUNCTION_HOOK(IDXGISwapChain* pThis, UINT SyncInterval, UI
         window2->AddBlock(new SettingsBlock());
         GUIWindows.emplace_back(window2);
 
+
+
 #ifdef DEV_TOOLS
 		GUIWindow* window3 = new GUIWindow("Positional Radar", 0);
         window3->AddBlock(new PositionRadarBlock());
@@ -187,6 +191,9 @@ HRESULT __stdcall D3D_FUNCTION_HOOK(IDXGISwapChain* pThis, UINT SyncInterval, UI
         overlayWindow = new GUIWindow("Overlay", ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
             ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove);
         overlayWindow->AddBlock(new OverlayBlock(&guiShowMenu));
+
+        imposterRadioWindow = new GUIWindow("Imposter Radio Active", 0);
+        imposterRadioWindow->AddBlock(new RadioSignalBlock());
     }
 
     ImGui_ImplDX11_NewFrame();
@@ -206,7 +213,13 @@ HRESULT __stdcall D3D_FUNCTION_HOOK(IDXGISwapChain* pThis, UINT SyncInterval, UI
         ImGui::SetNextWindowPos(ImVec2(io.DisplaySize.x / 2.0f, 10.0f),
             ImGuiCond_Always, ImVec2(0.5f, 0.0f));
         ImGui::SetNextWindowBgAlpha(0.5f);
+
         overlayWindow->Update();
+    }
+
+    // Render imposter radio
+    if (mumblePlayer.IsImposter()) {
+        imposterRadioWindow->Update();
     }
 
     ImGui::Render();

--- a/AUMInjector/user/MumblePlayer.cpp
+++ b/AUMInjector/user/MumblePlayer.cpp
@@ -73,6 +73,8 @@ void MumblePlayer::ResetState()
     InvalidatePositionCache();
     isSabotaged = false;
     isInMeeting = false;
+    lastReceived = 0;
+    radioIsInUse = false;
     if (isGhost)
         ExitGhostState();
     SetFullVolume();
@@ -154,7 +156,24 @@ bool MumblePlayer::IsUsingRadio() const
 
 void MumblePlayer::SetUsingRadio(bool usingRadio)
 {
-    this->isUsingRadio = usingRadio;
+    // Ensures that no one but imposters can use the radio
+    this->isUsingRadio = usingRadio && this->isImposter;
+}
+
+bool MumblePlayer::IsRadioInUse() const {
+    return radioIsInUse;
+}
+
+void MumblePlayer::SetRadioInUse(bool use) {
+    radioIsInUse = use;
+}
+
+long long MumblePlayer::LastRadioReceived() const {
+    return lastReceived;
+}
+
+void MumblePlayer::SetLastRadioReceived(long long t) {
+    lastReceived = t;
 }
 
 // In mumble (0.0f, 0.0f) lets users hear each other better
@@ -167,10 +186,10 @@ void MumblePlayer::SetFullVolume()
 // Sets the position cache, class may choose to override this value
 void MumblePlayer::SetPos(int i, float pos)
 {
-	if (isInMeeting) // Everyone in a meeting should be at 0,0
-		posCache[i] = 0.0f;
-	else if (!IsGhost())
-		posCache[i] = pos;
+    if (isInMeeting) // Everyone in a meeting should be at 0,0
+        posCache[i] = 0.0f;
+    else if (!IsGhost())
+        posCache[i] = pos;
     else
     {
         // Override position based on ghost voice mode

--- a/AUMInjector/user/MumblePlayer.h
+++ b/AUMInjector/user/MumblePlayer.h
@@ -89,6 +89,18 @@ public:
 	// Sets if the player is using radio
 	void SetUsingRadio(bool usingRadio);
 
+	// Returnsif the player received or sends a radio signal
+	bool IsRadioInUse() const;
+
+	// Sets if the player received or sends a radio signal
+	void SetRadioInUse(bool use);
+
+	// Returns the time for when the last radio signal was received
+	long long LastRadioReceived() const;
+
+	// Sets the time for when the last radio signal was received
+	void SetLastRadioReceived(long long t);
+
 private:
 	// --- Ghost State --- 
 	// Is the player currently a ghost
@@ -128,6 +140,7 @@ private:
 	// Cached player network id
 	int netID = 0;
 
+	// Is host flag
 	bool isHost = false;
 
 	// Imposter flag
@@ -136,6 +149,12 @@ private:
 	bool isUsingRadio = false;
 	// When you're using radio, teleport here
 	const float radioOffset = 19999.0f;
+
+	// When radio is in use by you or another imposter
+	bool radioIsInUse = false;
+
+	// Last time the radio signal was received
+	long long lastReceived = 0;
 
 	// Reads private information to display it to the user
 	friend class PlayerInfoBlock;

--- a/AUMInjector/user/main.cpp
+++ b/AUMInjector/user/main.cpp
@@ -73,7 +73,6 @@ void PlayerControl_FixedUpdate_Hook(PlayerControl* __this, MethodInfo* method)
         // Cache network ID
         mumblePlayer.SetNetID(__this->fields._.NetId);
 
-
         // From Player Control, get the Player Data
         PlayerData* Data = PlayerControl_GetData_Trampoline(__this, NULL);
         // And now we can get if we are imposter.
@@ -137,6 +136,16 @@ void BroadcastSettings(InnerNetClient* client)
     MessageWriter_EndMessage(writer, NULL);
 }
 
+// Broadcast the current settings
+void ImposterRadioUse(InnerNetClient* client)
+{
+    logger.Log(LOG_CODE::MSG, "Imposter Radio Useage is sent");
+
+    // Broadcast radio usage via RPC
+    MessageWriter* writer = InnerNetClient_StartRpc_Trampoline(client, mumblePlayer.GetNetID(), IMPOSTER_RADIO_RPC_ID, SendOption__Enum_Reliable, NULL);
+    MessageWriter_EndMessage(writer, NULL);
+}
+
 // Fixed loop for the game client
 void InnerNetClient_FixedUpdate_Hook(InnerNetClient* __this, MethodInfo* method)
 {
@@ -159,6 +168,29 @@ void InnerNetClient_FixedUpdate_Hook(InnerNetClient* __this, MethodInfo* method)
         }
     }
 
+    if (mumblePlayer.IsImposter()) {
+        long long timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+        if(mumblePlayer.IsUsingRadio()) 
+        {
+            // Only broadcast at most every second to prevent network overload
+            if ((timestamp - appSettings.lastBroadcastRadioMs) >= 500)
+            {
+                ImposterRadioUse(__this);
+                appSettings.lastBroadcastRadioMs = timestamp;
+                mumblePlayer.SetLastRadioReceived(timestamp);
+                mumblePlayer.SetRadioInUse(true);
+            }
+        }
+        else {
+            if ((timestamp - mumblePlayer.LastRadioReceived()) >= 600)
+            {
+                appSettings.lastBroadcastRadioMs = 0;
+                mumblePlayer.SetLastRadioReceived(0);
+                mumblePlayer.SetRadioInUse(false);
+            }
+        }
+    }
 
     // Check if game state changed to lobby
     if (__this->fields.GameState != lastGameState)
@@ -180,10 +212,9 @@ void InnerNetClient_FixedUpdate_Hook(InnerNetClient* __this, MethodInfo* method)
             // Just to be sure in case some join events were missed
             if(mumblePlayer.IsHost()) appSettings.mustBroadcast = true;
             mumblePlayer.EnterGame();
-
-
         }
     }
+
     lastGameState = __this->fields.GameState;
 
     if (mumbleLink.linkedMem != nullptr)
@@ -293,7 +324,7 @@ void InnerNetClient_HandleGameDataInner_Hook(InnerNetClient* __this, MessageRead
         int32_t pos = MessageReader_get_Position(reader, NULL);
         uint32_t targetObject = MessageReader_ReadPackedUInt32(reader, NULL); // Ignored
         uint8_t rpcId = MessageReader_ReadByte(reader, NULL);
-
+        
         // Check if this is a mod config packet
         if (rpcId == SYNC_RPC_ID)
         {
@@ -322,6 +353,19 @@ void InnerNetClient_HandleGameDataInner_Hook(InnerNetClient* __this, MessageRead
             appSettings.directionalAudio = (MessageReader_ReadByte(reader, NULL) == 1);
             appSettings.RecalculateAudioMap();
             logger.Log(LOG_CODE::MSG, "Got configuration: " + appSettings.HumanReadableSync());
+
+            // Swallow this packet
+            return;
+        }
+        // Check if this is an imposter radio call
+        else if (rpcId == IMPOSTER_RADIO_RPC_ID) 
+        {
+            if (mumblePlayer.IsImposter()) {
+                long long timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()).count();
+                mumblePlayer.SetLastRadioReceived(timestamp);
+                mumblePlayer.SetRadioInUse(true);
+            }
 
             // Swallow this packet
             return;

--- a/AUMInjector/user/settings.h
+++ b/AUMInjector/user/settings.h
@@ -8,6 +8,7 @@
 #define SYNC_VERSION 1 
 #define SYNC_SIZE 2 // Number of payload bytes
 #define SYNC_RPC_ID 42
+#define IMPOSTER_RADIO_RPC_ID 50
 
 // Credits info string
 static const std::string CREDITS = R"(AmongUs-Mumble mod by:
@@ -82,6 +83,8 @@ class Settings
 		bool mustBroadcast = false;
 		long long lastBroadcastMs = 0;
 
+		// Last time the radio broadcast signal was sent
+		long long lastBroadcastRadioMs = 0;
 
 		// Setup argument parser
 		Settings();


### PR DESCRIPTION
Related issue #72 
This broadcasts the useage of the radio via RPC every 500ms and draws an either green or red square for imposters, depending on if radio is in use or not.